### PR TITLE
Update marshaler.go Fix Prefix Bug.

### DIFF
--- a/framework/marshaler/marshaler.go
+++ b/framework/marshaler/marshaler.go
@@ -13,7 +13,7 @@ const prefix = "APRS: "
 
 // Unmarshals a raw APRS packet string to a Packet
 func Unmarshal(raw string) (*aprs.Packet, error) {
-	raw = strings.TrimLeft(raw, prefix)
+	raw = strings.TrimPrefix(raw, prefix)
 
 	defer func() {
 		if err := recover(); err != nil {


### PR DESCRIPTION
Changed TrimLeft to TrimPrefix in order to fix the callsigns starting with A bug.